### PR TITLE
Fix PrometheusRule comparison across namespaces

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,7 @@ pipeline:
   docker-latest:
     image: plugins/docker
     repo: quay.io/uswitch/heimdall
+    target: release
     registry: quay.io
     secrets: [ docker_username, docker_password ]
     tags:
@@ -27,6 +28,7 @@ pipeline:
   docker-tagged:
     image: plugins/docker
     repo: quay.io/uswitch/heimdall
+    target: release
     registry: quay.io
     secrets: [ docker_username, docker_password ]
     tags:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM golang:1.12.1-alpine3.9 as debug
-ENV CGO_ENABLED 0
-WORKDIR /
-ADD bin/heimdall heimdall
+
 RUN set -ex; \
     apk add --no-cache \
         git \
     ; \
-    go get github.com/derekparker/delve/cmd/dlv;
+    CGO_ENABLED=0 go get github.com/derekparker/delve/cmd/dlv;
+
+WORKDIR /
+ADD bin/heimdall heimdall
 
 ENTRYPOINT ["/go/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/heimdall", "--"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,14 @@ RUN set -ex; \
     CGO_ENABLED=0 go get github.com/derekparker/delve/cmd/dlv;
 
 WORKDIR /
-ADD bin/heimdall heimdall
+COPY bin/heimdall heimdall
 
 ENTRYPOINT ["/go/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/heimdall", "--"]
 
 CMD ["--json"]
 
 FROM scratch as release
-ADD bin/heimdall heimdall
+COPY bin/heimdall heimdall
 
 ENTRYPOINT ["/heimdall"]
 

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: heimdall
       containers:
       - name: heimdall
-        image: quay.io/uswitch/heimdall:v0.5.0
+        image: quay.io/uswitch/heimdall:v0.5.2
         args:
         - --json
         resources:
@@ -61,13 +61,13 @@ data:
     apiVersion: monitoring.coreos.com/v1
     kind: PrometheusRule
     metadata:
-      name: {{.Name}}-5xx-rate
+      name: {{.Namespace}}-{{.Name}}-5xx-rate
       namespace: ingress
       labels:
         role: alert-rules
     spec:
       groups:
-      - name: {{.Name}}-5xx-rate.rules
+      - name: {{.Namespace}}-{{.Name}}-5xx-rate.rules
         rules:
         - alert: {{.Name}}-5xx-rate
           annotations:

--- a/example-prometheusrule-templates/5xx-rate.tmpl
+++ b/example-prometheusrule-templates/5xx-rate.tmpl
@@ -2,13 +2,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{.Name}}-5xx-rate
+  name: {{.Namespace}}-{{.Name}}-5xx-rate
   namespace: ingress
   labels:
     role: alert-rules
 spec:
   groups:
-  - name: {{.Name}}-5xx-rate.rules
+  - name: {{.Namespace}}-{{.Name}}-5xx-rate.rules
     rules:
     - alert: {{.Name}}-5xx-rate
       annotations:


### PR DESCRIPTION
Now that we are no longer confined by namespace of the Ingress object, we have to check all namespaces for preexisting PrometheusRules, and then compare PrometheusRules by their key ("namespace/name") instead of just a name.

Additionally, we should add namespace of Ingress object into the name of PrometheusRule object within our example templates, so that identically named Ingresses in different namespaces would not cause name collision  while creating PrometheusRules within hardcoded (within example template) namespace.