### PR TITLE
SRE-185 - Prom Rules for Ingresses are put in the same NS as the Ingress is found

### DIFF
--- a/kube/config/templates/5xx-rate.tmpl
+++ b/kube/config/templates/5xx-rate.tmpl
@@ -3,8 +3,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{.Namespace}}-{{.Name}}-5xx-rate
-  namespace: ingress
+  namespace: {{.Namespace}}
   labels:
+    prometheus: {{.NSPrometheus}}
     role: alert-rules
 spec:
   groups:

--- a/pkg/templates/promrules.go
+++ b/pkg/templates/promrules.go
@@ -30,13 +30,14 @@ type PrometheusRuleTemplateManager struct {
 // templateParameter
 // - struct passed to each promrule template
 type templateParameterIngress struct {
-	Identifier string
-	Threshold  string
-	Namespace  string
-	Name       string
-	Host       string
-	Value      string
-	Ingress    *extensionsv1beta1.Ingress
+	Identifier   string
+	Threshold    string
+	Namespace    string
+	Name         string
+	Host         string
+	Value        string
+	NSPrometheus string
+	Ingress      *extensionsv1beta1.Ingress
 }
 
 type templateParameterDeployment struct {
@@ -96,14 +97,15 @@ func NewPrometheusRuleTemplateManager(directory string) (*PrometheusRuleTemplate
 
 // CreateFromIngress
 // - Creates all the promRules for a given Ingress
-func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *extensionsv1beta1.Ingress) ([]*monitoringv1.PrometheusRule, error) {
+func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *extensionsv1beta1.Ingress, ingressNamespacePrometheus string) ([]*monitoringv1.PrometheusRule, error) {
 	ingressIdentifier := fmt.Sprintf("%s.%s", ingress.Namespace, ingress.Name)
 
 	params := &templateParameterIngress{
-		Ingress:    ingress,
-		Identifier: ingressIdentifier,
-		Namespace:  ingress.Namespace,
-		Name:       ingress.Name,
+		Ingress:      ingress,
+		Identifier:   ingressIdentifier,
+		Namespace:    ingress.Namespace,
+		Name:         ingress.Name,
+		NSPrometheus: ingressNamespacePrometheus,
 	}
 
 	prometheusRules := map[string]*monitoringv1.PrometheusRule{}


### PR DESCRIPTION
From now on Prometheus Rules generated for Ingresses, will be put into the same namespace where the Ingress lives.