### PR TITLE
CH - SRE-290 - Getting Prometheus Name from the Namespace's labels

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -252,7 +252,7 @@ func (c *Controller) processDeployment(namespace, name string) error {
 		return err
 	}
 
-	deploymentNamespacePrometheus := deploymentNamespace.GetAnnotations()["prometheus"]
+	deploymentNamespacePrometheus := deploymentNamespace.GetLabels()["prometheus"]
 
 	log.Sugar.Debugw("Prometheus instance for alert", "deployment", name, "namespace", namespace, "prometheus", deploymentNamespacePrometheus)
 	newPrometheusRules, err := c.templateManager.CreateFromDeployment(deployment, deploymentNamespacePrometheus)


### PR DESCRIPTION
Discovered during working on the new alerting journey. Namespace-specific Prometheus instances should be identified by getting the Prometheus name from the namespace's labels, rather than from the annotations.