### PR TITLE
RE-234 - Exposing the owner label from the alert to Opsgenie.

### DIFF
--- a/pkg/templates/promrules.go
+++ b/pkg/templates/promrules.go
@@ -22,6 +22,7 @@ import (
 var heimPrefix = "com.uswitch.heimdall"
 
 const (
+	ownerAnnotation       = "service.rvu.co.uk/owner"
 	environmentAnnotation = "service.rvu.co.uk/environment"
 	criticalityAnnotation = "service.rvu.co.uk/criticality"
 	sensitivityAnnotation = "service.rvu.co.uk/sensitivity"
@@ -55,6 +56,7 @@ type templateParameterDeployment struct {
 	Value               string
 	GeneratedLabels     string
 	NSPrometheus        string
+	Owner               string
 	Environment         string
 	Criticality         string
 	Sensitivity         string
@@ -169,6 +171,7 @@ func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *extensionsv1b
 func (a *PrometheusRuleTemplateManager) CreateFromDeployment(deployment *apps.Deployment, depNamespacePrometheus string) ([]*monitoringv1.PrometheusRule, error) {
 	deploymentIdentifier := fmt.Sprintf("%s.%s", deployment.Namespace, deployment.Name)
 
+	owner := deployment.GetAnnotations()[ownerAnnotation]
 	criticality := deployment.GetAnnotations()[criticalityAnnotation]
 	environment := deployment.GetAnnotations()[environmentAnnotation]
 	sensitivity := deployment.GetAnnotations()[sensitivityAnnotation]
@@ -188,6 +191,7 @@ func (a *PrometheusRuleTemplateManager) CreateFromDeployment(deployment *apps.De
 		Namespace:       deployment.Namespace,
 		Name:            deployment.Name,
 		GeneratedLabels: generatedLabels,
+		Owner:           owner,
 		Criticality:     criticality,
 		Environment:     environment,
 		Sensitivity:     sensitivity,


### PR DESCRIPTION
This was requested by LTV as they have services that change ownerships, and some deployments are still living in the old 
namespace, so they need to differentiate between services that have different owners in the very same namespace.

Further details are found on [this JIRA ticket](https://rvu.atlassian.net/secure/RapidBoard.jspa?rapidView=17&projectKey=RE&modal=detail&selectedIssue=RE-234).