### PR TITLE
RE-463 - Improvements in looking up ingress owner

### DIFF
--- a/kube/config/templates/5xx-rate.tmpl
+++ b/kube/config/templates/5xx-rate.tmpl
@@ -33,7 +33,15 @@ spec:
         identifier: {{.Identifier}}
         name: {{.Name}}-5xx-rate
         namespace: {{.Namespace}}
+        {{if .Owner}}
         owner: {{.Owner}}
+        {{end}}
+        {{if .Environment}}
         environment: {{.Environment}}
+        {{end}}
+        {{if .Criticality}}
         criticality: {{.Criticality}}
+        {{end}}
+        {{if .Sensitivity}}
         sensitivity: {{.Sensitivity}}
+        {{end}}

--- a/kube/config/templates/replicas-availability-deployment.tmpl
+++ b/kube/config/templates/replicas-availability-deployment.tmpl
@@ -25,7 +25,15 @@ spec:
         name: {{.Name}}-replicas-availability-deployment
         namespace: {{.Namespace}}
         deployment: {{.Name}}
+        {{if .Owner}}
         owner: {{.Owner}}
+        {{end}}
+        {{if .Environment}}
         environment: {{.Environment}}
+        {{end}}
+        {{if .Criticality}}
         criticality: {{.Criticality}}
+        {{end}}
+        {{if .Sensitivity}}
         sensitivity: {{.Sensitivity}}
+        {{end}}

--- a/pkg/templates/deployment.go
+++ b/pkg/templates/deployment.go
@@ -94,7 +94,7 @@ func (a *PrometheusRuleTemplateManager) CreateFromDeployment(deployment *apps.De
 
 		promrule := &monitoringv1.PrometheusRule{}
 
-		if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(result.Bytes()), 1024).Decode(promrule); err != nil {
+		if err := yaml.NewYAMLOrJSONDecoder(&result, 1024).Decode(promrule); err != nil {
 			warnMessage := fmt.Sprintf("[deployment][%s] error parsing YAML: %s", deploymentIdentifier, err)
 			log.Sugar.Warnf(warnMessage)
 			sentryclient.SentryMessage(warnMessage)

--- a/pkg/templates/ingress.go
+++ b/pkg/templates/ingress.go
@@ -205,12 +205,7 @@ func (a *PrometheusRuleTemplateManager) listPodOwnerReferences(selector map[stri
 		podsMeta = append(podsMeta, &pod.ObjectMeta)
 	}
 
-	uniqPodOwnerRef, err := uniqueOwnerReferences(podsMeta)
-	if err != nil {
-		return nil, fmt.Errorf("error getting unique pod owner references: %v", err)
-	}
-
-	return uniqPodOwnerRef, nil
+	return uniqueOwnerReferences(podsMeta), nil
 }
 
 func (a *PrometheusRuleTemplateManager) getReplicasetOwnerReferences(podOwners map[string]metav1.OwnerReference, namespace string) (map[string]metav1.OwnerReference, error) {
@@ -225,12 +220,7 @@ func (a *PrometheusRuleTemplateManager) getReplicasetOwnerReferences(podOwners m
 		replicasetsMeta = append(replicasetsMeta, replicasetMeta)
 	}
 
-	uniqReplicasetOwnerRefs, err := uniqueOwnerReferences(replicasetsMeta)
-	if err != nil {
-		return nil, fmt.Errorf("error getting unique replicaset owner references: %v", err)
-	}
-
-	return uniqReplicasetOwnerRefs, nil
+	return uniqueOwnerReferences(replicasetsMeta), nil
 }
 
 func (a *PrometheusRuleTemplateManager) getDeployments(replicasetOwners map[string]metav1.OwnerReference, namespace string) ([]*metav1.ObjectMeta, error) {
@@ -246,8 +236,8 @@ func (a *PrometheusRuleTemplateManager) getDeployments(replicasetOwners map[stri
 	}
 
 	var deployments []*metav1.ObjectMeta
-	for _, d := range uniqDeployments {
-		deployments = append(deployments, d)
+	for _, deployment := range uniqDeployments {
+		deployments = append(deployments, deployment)
 	}
 
 	return deployments, nil
@@ -273,7 +263,7 @@ func (a *PrometheusRuleTemplateManager) getAppsObjectMeta(name, namespace, kind 
 	}
 }
 
-func uniqueOwnerReferences(objects []*metav1.ObjectMeta) (map[string]metav1.OwnerReference, error) {
+func uniqueOwnerReferences(objects []*metav1.ObjectMeta) map[string]metav1.OwnerReference {
 	uniqueOwnerReferences := make(map[string]metav1.OwnerReference)
 
 	for _, object := range objects {
@@ -281,5 +271,5 @@ func uniqueOwnerReferences(objects []*metav1.ObjectMeta) (map[string]metav1.Owne
 			uniqueOwnerReferences[fmt.Sprintf("%s/%s/%s", owner.APIVersion, owner.Kind, owner.Name)] = owner
 		}
 	}
-	return uniqueOwnerReferences, nil
+	return uniqueOwnerReferences
 }

--- a/pkg/templates/ingress.go
+++ b/pkg/templates/ingress.go
@@ -82,7 +82,7 @@ func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *extensionsv1b
 
 		promrule := &monitoringv1.PrometheusRule{}
 
-		if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(result.Bytes()), 1024).Decode(promrule); err != nil {
+		if err := yaml.NewYAMLOrJSONDecoder(&result, 1024).Decode(promrule); err != nil {
 			warnMessage := fmt.Sprintf("[ingress][%s] error parsing YAML: %s", ingressIdentifier, err)
 			log.Sugar.Warnf(warnMessage)
 			sentryclient.SentryMessage(warnMessage)


### PR DESCRIPTION
This is a slight update to the last PR #25 which improves how we lookup an ingress' owner:
* We try and get a unique service for the ingress and grab it's selector
* The service selector is used to list the matching pods (as this is how services actually work in kube)
* Owner references from the pods are used to find matching replicasets 
* Owner references from the replicasets are used to find matching deployments
* As before, if we have a single deployment then we grab its annotations to get service standard labels like: owner, criticality, sensitivity, and environment