### PR TITLE
Add labels from annotations

### DIFF
--- a/kube/config/templates/5xx-rate.tmpl
+++ b/kube/config/templates/5xx-rate.tmpl
@@ -45,3 +45,6 @@ spec:
         {{if .Sensitivity}}
         sensitivity: {{.Sensitivity}}
         {{end}}
+        {{if .Priority}}
+        priority: {{.Priority}}
+        {{end}}

--- a/kube/config/templates/5xx-rate.tmpl
+++ b/kube/config/templates/5xx-rate.tmpl
@@ -45,6 +45,6 @@ spec:
         {{if .Sensitivity}}
         sensitivity: {{.Sensitivity}}
         {{end}}
-        {{if .Priority}}
-        priority: {{.Priority}}
+        {{range $key, $value := .CustomLabels}}
+        {{$key}}: {{$value}}
         {{end}}

--- a/kube/config/templates/replicas-availability-deployment.tmpl
+++ b/kube/config/templates/replicas-availability-deployment.tmpl
@@ -37,3 +37,6 @@ spec:
         {{if .Sensitivity}}
         sensitivity: {{.Sensitivity}}
         {{end}}
+        {{if .Priority}}
+        priority: {{.Priority}}
+        {{end}}

--- a/kube/config/templates/replicas-availability-deployment.tmpl
+++ b/kube/config/templates/replicas-availability-deployment.tmpl
@@ -37,6 +37,6 @@ spec:
         {{if .Sensitivity}}
         sensitivity: {{.Sensitivity}}
         {{end}}
-        {{if .Priority}}
-        priority: {{.Priority}}
+        {{range $key, $value := .CustomLabels}}
+        {{$key}}: {{$value}}
         {{end}}

--- a/pkg/templates/deployment.go
+++ b/pkg/templates/deployment.go
@@ -31,6 +31,7 @@ type templateParameterDeployment struct {
 	Criticality         string
 	Sensitivity         string
 	Deployment          *apps.Deployment
+	Priority            string
 }
 
 // CreateFromDeployment
@@ -73,6 +74,8 @@ func (a *PrometheusRuleTemplateManager) CreateFromDeployment(deployment *apps.De
 		if !strings.HasPrefix(k, heimPrefix) {
 			continue
 		}
+
+		params.Priority = deployment.GetAnnotations()[priorityAnnotation]
 
 		templateName := strings.TrimLeft(k, fmt.Sprintf("%s/", heimPrefix))
 		logger.Infow("template selected", "template", templateName)

--- a/pkg/templates/deployment.go
+++ b/pkg/templates/deployment.go
@@ -31,7 +31,7 @@ type templateParameterDeployment struct {
 	Criticality         string
 	Sensitivity         string
 	Deployment          *apps.Deployment
-	Priority            string
+	CustomLabels        map[string]string
 }
 
 // CreateFromDeployment
@@ -69,13 +69,17 @@ func (a *PrometheusRuleTemplateManager) CreateFromDeployment(deployment *apps.De
 
 	prometheusRules := map[string]*monitoringv1.PrometheusRule{}
 	annotations := params.Deployment.GetAnnotations()
-
 	for k, v := range annotations {
 		if !strings.HasPrefix(k, heimPrefix) {
 			continue
 		}
 
-		params.Priority = deployment.GetAnnotations()[priorityAnnotation]
+		// Skip label-* annotations as they are not templates
+		if strings.HasPrefix(k, labelPrefix) {
+			continue
+		}
+
+		params.CustomLabels = extractCustomLabels(annotations)
 
 		templateName := strings.TrimLeft(k, fmt.Sprintf("%s/", heimPrefix))
 		logger.Infow("template selected", "template", templateName)

--- a/pkg/templates/deployment.go
+++ b/pkg/templates/deployment.go
@@ -69,6 +69,8 @@ func (a *PrometheusRuleTemplateManager) CreateFromDeployment(deployment *apps.De
 
 	prometheusRules := map[string]*monitoringv1.PrometheusRule{}
 	annotations := params.Deployment.GetAnnotations()
+	params.CustomLabels = extractCustomLabels(annotations)
+
 	for k, v := range annotations {
 		if !strings.HasPrefix(k, heimPrefix) {
 			continue
@@ -78,8 +80,6 @@ func (a *PrometheusRuleTemplateManager) CreateFromDeployment(deployment *apps.De
 		if strings.HasPrefix(k, labelPrefix) {
 			continue
 		}
-
-		params.CustomLabels = extractCustomLabels(annotations)
 
 		templateName := strings.TrimLeft(k, fmt.Sprintf("%s/", heimPrefix))
 		logger.Infow("template selected", "template", templateName)

--- a/pkg/templates/deployment_test.go
+++ b/pkg/templates/deployment_test.go
@@ -34,6 +34,31 @@ var (
 			Selector: &metav1.LabelSelector{},
 		},
 	}
+
+	testDeploymentMultiLabel = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testAppMulti",
+			Namespace: "testNamespace",
+			Labels: map[string]string{
+				"app": "testAppMulti",
+			},
+			Annotations: map[string]string{
+				ownerAnnotation:       "testDeploymentOwner",
+				environmentAnnotation: "testing",
+				criticalityAnnotation: "low",
+				sensitivityAnnotation: "public",
+				"com.uswitch.heimdall/label-priority": "p3",
+				"com.uswitch.heimdall/label-channel":  "testing",
+				"com.uswitch.heimdall/label-team":     "platform",
+				"com.uswitch.heimdall/replicas-availability-deployment": "1",
+			},
+			OwnerReferences: []metav1.OwnerReference{},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: new(int32),
+			Selector: &metav1.LabelSelector{},
+		},
+	}
 )
 
 func TestDeploymentAnnotations(t *testing.T) {
@@ -56,4 +81,19 @@ kube_deployment_spec_replicas{namespace="testNamespace", deployment="testApp"} <
 	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["criticality"], "low")
 	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["sensitivity"], "public")
 	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["priority"], "p1")
+}
+
+func TestDeploymentMultipleCustomLabels(t *testing.T) {
+	log.Setup(log.DEBUG_LEVEL)
+
+	client := fake.NewSimpleClientset()
+
+	template, err := NewPrometheusRuleTemplateManager("../../kube/config/templates", client)
+
+	promrules, err := template.CreateFromDeployment(testDeploymentMultiLabel, "testNamespace")
+	assert.Assert(t, is.Nil(err))
+	assert.Assert(t, is.Len(promrules, 1))
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["priority"], "p3")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["channel"], "testing")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["team"], "platform")
 }

--- a/pkg/templates/deployment_test.go
+++ b/pkg/templates/deployment_test.go
@@ -24,6 +24,7 @@ var (
 				environmentAnnotation: "testing",
 				criticalityAnnotation: "low",
 				sensitivityAnnotation: "public",
+				priorityAnnotation:    "p1",
 				"com.uswitch.heimdall/replicas-availability-deployment": "1",
 			},
 			OwnerReferences: []metav1.OwnerReference{},
@@ -51,4 +52,8 @@ kube_deployment_spec_replicas{namespace="testNamespace", deployment="testApp"} <
 	assert.Assert(t, is.Len(promrules, 1))
 	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Expr.StrVal, expr)
 	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["owner"], "testDeploymentOwner")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["environment"], "testing")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["criticality"], "low")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["sensitivity"], "public")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["priority"], "p1")
 }

--- a/pkg/templates/ingress.go
+++ b/pkg/templates/ingress.go
@@ -47,7 +47,6 @@ func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *networkingv1.
 		Environment: ingress.GetAnnotations()[environmentAnnotation],
 		Criticality: ingress.GetAnnotations()[criticalityAnnotation],
 		Sensitivity: ingress.GetAnnotations()[sensitivityAnnotation],
-		Priority:    ingress.GetAnnotations()[priorityAnnotation],
 	}
 
 	prometheusRules := map[string]*monitoringv1.PrometheusRule{}
@@ -57,6 +56,8 @@ func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *networkingv1.
 		if !strings.HasPrefix(k, heimPrefix) {
 			continue
 		}
+
+		params.Priority = ingress.GetAnnotations()[priorityAnnotation]
 
 		templateName := strings.TrimLeft(k, fmt.Sprintf("%s/", heimPrefix))
 		template, ok := a.templates[templateName]
@@ -124,6 +125,7 @@ func (a *PrometheusRuleTemplateManager) resolveIngressOwner(params *templatePara
 	params.Environment = deployment.GetAnnotations()[environmentAnnotation]
 	params.Criticality = deployment.GetAnnotations()[criticalityAnnotation]
 	params.Sensitivity = deployment.GetAnnotations()[sensitivityAnnotation]
+	params.Priority = deployment.GetAnnotations()[priorityAnnotation]
 
 	return params, nil
 }

--- a/pkg/templates/ingress.go
+++ b/pkg/templates/ingress.go
@@ -29,6 +29,7 @@ type templateParameterIngress struct {
 	Criticality    string
 	Sensitivity    string
 	BackendService string
+	Priority       string
 }
 
 // CreateFromIngress
@@ -46,6 +47,7 @@ func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *networkingv1.
 		Environment: ingress.GetAnnotations()[environmentAnnotation],
 		Criticality: ingress.GetAnnotations()[criticalityAnnotation],
 		Sensitivity: ingress.GetAnnotations()[sensitivityAnnotation],
+		Priority:    ingress.GetAnnotations()[priorityAnnotation],
 	}
 
 	prometheusRules := map[string]*monitoringv1.PrometheusRule{}

--- a/pkg/templates/ingress.go
+++ b/pkg/templates/ingress.go
@@ -29,7 +29,7 @@ type templateParameterIngress struct {
 	Criticality    string
 	Sensitivity    string
 	BackendService string
-	Priority       string
+	CustomLabels   map[string]string
 }
 
 // CreateFromIngress
@@ -57,7 +57,12 @@ func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *networkingv1.
 			continue
 		}
 
-		params.Priority = ingress.GetAnnotations()[priorityAnnotation]
+		// Skip label-* annotations as they are not templates
+		if strings.HasPrefix(k, labelPrefix) {
+			continue
+		}
+
+		params.CustomLabels = extractCustomLabels(annotations)
 
 		templateName := strings.TrimLeft(k, fmt.Sprintf("%s/", heimPrefix))
 		template, ok := a.templates[templateName]
@@ -125,7 +130,6 @@ func (a *PrometheusRuleTemplateManager) resolveIngressOwner(params *templatePara
 	params.Environment = deployment.GetAnnotations()[environmentAnnotation]
 	params.Criticality = deployment.GetAnnotations()[criticalityAnnotation]
 	params.Sensitivity = deployment.GetAnnotations()[sensitivityAnnotation]
-	params.Priority = deployment.GetAnnotations()[priorityAnnotation]
 
 	return params, nil
 }

--- a/pkg/templates/ingress.go
+++ b/pkg/templates/ingress.go
@@ -51,6 +51,7 @@ func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *networkingv1.
 
 	prometheusRules := map[string]*monitoringv1.PrometheusRule{}
 	annotations := ingress.GetAnnotations()
+	params.CustomLabels = extractCustomLabels(annotations)
 
 	for k, v := range annotations {
 		if !strings.HasPrefix(k, heimPrefix) {
@@ -61,8 +62,6 @@ func (a *PrometheusRuleTemplateManager) CreateFromIngress(ingress *networkingv1.
 		if strings.HasPrefix(k, labelPrefix) {
 			continue
 		}
-
-		params.CustomLabels = extractCustomLabels(annotations)
 
 		templateName := strings.TrimLeft(k, fmt.Sprintf("%s/", heimPrefix))
 		template, ok := a.templates[templateName]

--- a/pkg/templates/ingress_test.go
+++ b/pkg/templates/ingress_test.go
@@ -69,12 +69,12 @@ var (
 			Name:      "testDefaultBackend",
 			Namespace: "testNamespace",
 			Annotations: map[string]string{
-				"com.uswitch.heimdall/5xx-rate":       "0.001",
-				"com.uswitch.heimdall/label-priority": "p1",
-				ownerAnnotation:                       "testIngressOwner",
-				environmentAnnotation:                 "testing",
-				criticalityAnnotation:                 "low",
-				sensitivityAnnotation:                 "public",
+				"com.uswitch.heimdall/5xx-rate": "0.001",
+				ownerAnnotation:                 "testIngressOwner",
+				environmentAnnotation:           "testing",
+				criticalityAnnotation:           "low",
+				sensitivityAnnotation:           "public",
+				priorityAnnotation:              "p1",
 			},
 		},
 		Spec: networkingv1.IngressSpec{

--- a/pkg/templates/ingress_test.go
+++ b/pkg/templates/ingress_test.go
@@ -120,6 +120,33 @@ var (
 			},
 		},
 	}
+
+	testIngressMultiLabel = &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testMultiLabel",
+			Namespace: "testNamespace",
+			Annotations: map[string]string{
+				"com.uswitch.heimdall/5xx-rate":       "0.001",
+				ownerAnnotation:                       "testIngressOwner",
+				environmentAnnotation:                 "testing",
+				criticalityAnnotation:                 "low",
+				sensitivityAnnotation:                 "public",
+				"com.uswitch.heimdall/label-priority": "p2",
+				"com.uswitch.heimdall/label-channel":  "testing",
+				"com.uswitch.heimdall/label-region":   "eu-west-1",
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			DefaultBackend: &networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: "testService",
+					Port: networkingv1.ServiceBackendPort{
+						Number: 80,
+					},
+				},
+			},
+		},
+	}
 )
 
 func TestIngressAnnotationsDefaultBackend(t *testing.T) {
@@ -191,3 +218,19 @@ func TestNamesMatch(t *testing.T) {
 	service = checkNamesMatch(services)
 	assert.Equal(t, "", service)
 }
+
+func TestIngressMultipleCustomLabels(t *testing.T) {
+	log.Setup(log.DEBUG_LEVEL)
+
+	client := fake.NewSimpleClientset(testService, testDeployment, testReplicaset, testPod)
+
+	template, err := NewPrometheusRuleTemplateManager("../../kube/config/templates", client)
+
+	promrules, err := template.CreateFromIngress(testIngressMultiLabel)
+	assert.Assert(t, is.Nil(err))
+	assert.Assert(t, is.Len(promrules, 1))
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["priority"], "p2")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["channel"], "testing")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["region"], "eu-west-1")
+}
+

--- a/pkg/templates/ingress_test.go
+++ b/pkg/templates/ingress_test.go
@@ -69,11 +69,12 @@ var (
 			Name:      "testDefaultBackend",
 			Namespace: "testNamespace",
 			Annotations: map[string]string{
-				"com.uswitch.heimdall/5xx-rate": "0.001",
-				ownerAnnotation:                 "testIngressOwner",
-				environmentAnnotation:           "testing",
-				criticalityAnnotation:           "low",
-				sensitivityAnnotation:           "public",
+				"com.uswitch.heimdall/5xx-rate":       "0.001",
+				"com.uswitch.heimdall/label-priority": "p1",
+				ownerAnnotation:                       "testIngressOwner",
+				environmentAnnotation:                 "testing",
+				criticalityAnnotation:                 "low",
+				sensitivityAnnotation:                 "public",
 			},
 		},
 		Spec: networkingv1.IngressSpec{
@@ -147,6 +148,10 @@ func TestIngressAnnotationsDefaultBackend(t *testing.T) {
 	assert.Assert(t, is.Len(promrules, 1))
 	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Expr.StrVal, expr)
 	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["owner"], "testIngressOwner")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["environment"], "testing")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["criticality"], "low")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["sensitivity"], "public")
+	assert.Equal(t, promrules[0].Spec.Groups[0].Rules[0].Labels["priority"], "p1")
 }
 
 func TestIngressAnnotationsRuleBackend(t *testing.T) {

--- a/pkg/templates/promrules.go
+++ b/pkg/templates/promrules.go
@@ -21,6 +21,7 @@ const (
 	environmentAnnotation = "service.rvu.co.uk/environment"
 	criticalityAnnotation = "service.rvu.co.uk/criticality"
 	sensitivityAnnotation = "service.rvu.co.uk/sensitivity"
+	priorityAnnotation    = "com.uswitch.heimdall/label-priority"
 )
 
 // ClientSetI

--- a/pkg/templates/promrules.go
+++ b/pkg/templates/promrules.go
@@ -14,7 +14,10 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var heimPrefix = "com.uswitch.heimdall"
+var (
+	heimPrefix  = "com.uswitch.heimdall"
+	labelPrefix = "com.uswitch.heimdall/label-"
+)
 
 const (
 	ownerAnnotation       = "service.rvu.co.uk/owner"
@@ -79,4 +82,18 @@ func collectPrometheusRules(prometheusRules map[string]*monitoringv1.PrometheusR
 	}
 
 	return ret
+}
+
+// com.uswitch.heimdall/label-priority: p3 -> map["priority"] = "p3"
+func extractCustomLabels(annotations map[string]string) map[string]string {
+	customLabels := make(map[string]string)
+
+	for k, v := range annotations {
+		if strings.HasPrefix(k, labelPrefix) {
+			labelName := strings.TrimPrefix(k, labelPrefix)
+			customLabels[labelName] = v
+		}
+	}
+
+	return customLabels
 }


### PR DESCRIPTION
Enables adding labels to generated prometheus rules with annotations like:
`com.uswitch.heimdall/label-priority: p3` 